### PR TITLE
Feature/face preprocess/feat: Add handling Non-RGB channel

### DIFF
--- a/ai_api_server/face_preprocess.py
+++ b/ai_api_server/face_preprocess.py
@@ -104,6 +104,15 @@ def align_pil_image(img: Image.Image)->Image.Image:
                 img = img.transpose(Image.ROTATE_90)
     return img
 
+def convert_to_rgb(image_array):
+    if len(image_array.shape) == 2:
+        rgb_image = cv2.cvtColor(image_array, cv2.COLOR_GRAY2RGB)
+    elif image_array.shape[2] == 4:
+        rgb_image = cv2.cvtColor(image_array, cv2.COLOR_RGBA2RGB)
+    else:
+        rgb_image = image_array
+    return rgb_image
+
 def preprocess_image(images: List[Image.Image], bg: Background, face_detector: FaceDetector, head_segmenter: HeadSegmenter) -> List[Image.Image]:
     """
 
@@ -125,8 +134,7 @@ def preprocess_image(images: List[Image.Image], bg: Background, face_detector: F
         print("Invalid Background color", bg)
         raise ValueError("Invalid Background color")
 
-    ndarr_images = [np.array(image) for image in images]
-    
+    ndarr_images = [convert_to_rgb(np.array(image)) for image in images]    
     results = face_detector.detect(ndarr_images)
     cropped_images = face_detector.crop_faces(results=results, image=ndarr_images, margin=2.5)
     processed_images = head_segmenter.segment_and_color(images=cropped_images, bg_color=bg_color)
@@ -160,3 +168,15 @@ if __name__ == "__main__":
     
     for i, result in enumerate(results):
         result.save(f'./test_{i}.jpg')
+
+def convert_to_rgb(image_path):
+    image = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+    
+    if len(image.shape) == 2:
+        rgb_image = cv2.cvtColor(image, cv2.COLOR_GRAY2RGB)
+    elif image.shape[2] == 4:
+        rgb_image = cv2.cvtColor(image, cv2.COLOR_RGBA2RGB)
+    else:
+        rgb_image = image
+    
+    return rgb_image


### PR DESCRIPTION
## Motivation
전처리 모듈 중 입력 사진이 JPG가 아닐 경우, 특히 PNG 사진 등에서 RGBA 채널이 전달되는 경우 face_detector (YOLO) 가 터지는 오류를 테스트 중 발견했습니다. AI 서버 이전 단계에서 JPG 변환기가 작동하지만, 해당 변환기의 오류 가능성 및 AI 로직의 강건함을 위해 RGB 및 GRAYSCALE 이미지를 모두 RGB 채널로 변경하도록 코드를 추가했습니다. 

## Key Changes
### `convert_to_rgb` 함수 추가
- 입력 Type: ndarray
- 출력 Type: ndarray

## Usage Example
preprocess_image 전체 로직 중에 다음 코드 부분만 변경했습니다.

Before:
```
ndarr_images = [np.array(image) for image in images]    
```
After:
```
ndarr_images = [convert_to_rgb(np.array(image)) for image in images]    
```

올바르게 작동한다면, 추가적인 수정은 필요하지 않습니다.

## To Reviewers
opencv만 필요하기 때문에 기존 종속성 수정 필요 없습니다.
올바르게 작동하는지만 점검해 주시면 될 것 같습니다.
우선 AI 서버 이전 JPG 변환기가 올바르게 작동해야 합니다.